### PR TITLE
Prepend 'base_url_simple' to get true file paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.2.3
+##  15-08-2019
+
+1. [](#bugfix)
+    * Prepend base url to get true paths for files.
+
 # v0.2.2
 ##  12-08-2019
 

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,5 +1,5 @@
 name: File Browser
-version: 0.2.2
+version: 0.2.3
 description: File browser plugin providing directory listing
 icon: folder
 author:

--- a/templates/file_browser_plugin.html.twig
+++ b/templates/file_browser_plugin.html.twig
@@ -18,7 +18,8 @@
   "built_in_css": true,
   "use_alt_arrows": false,
   "show_thumbnails": true,
-  "icon_weight": "fas"
+  "icon_weight": "fas",
+  "base_url": base_url_simple
 } %}
 
 {% set options = default_config|merge(plugin_config)|merge(page_config) %}

--- a/templates/macros/file_browser.twig
+++ b/templates/macros/file_browser.twig
@@ -99,7 +99,7 @@
   {% endfor %}
 
   <div class="item">
-    <a class="file" href="{{ url }}" target="_blank">
+    <a class="file" href="{{ options["base_url"] }}/{{ url }}" target="_blank">
       {# Need to check the file "type" because bmp and tiff files aren't supported #}
       <div class="thumbnail">
         {% if showThumbnails and fileMedia["mime"]|starts_with("image") and fileMedia["type"] is not same as("file") %}


### PR DESCRIPTION
This PR resolves #5 by making URLs absolute with respect to the site URL, and prepending `base_url_simple` to handle cases where Grav is hosted in a subdirectory.